### PR TITLE
Improve nodes broadcasting

### DIFF
--- a/lib/nebulex_local_distributed_adapter/sidecar.ex
+++ b/lib/nebulex_local_distributed_adapter/sidecar.ex
@@ -1,0 +1,30 @@
+defmodule NebulexLocalDistributedAdapter.Sidecar do
+  @moduledoc false
+  use GenServer
+
+  import Nebulex.Helpers
+
+  alias Nebulex.Cache.Cluster
+
+  @doc false
+  def start_link(%{name: name} = adapter_meta) do
+    GenServer.start_link(__MODULE__, adapter_meta, name: normalize_module_name([name, Sidecar]))
+  end
+
+  @impl true
+  def init(adapter_meta) do
+    # Trap exit signals to run cleanup job
+    _ = Process.flag(:trap_exit, true)
+
+    # Ensure joining the cluster only when the cache supervision tree is started
+    :ok = Cluster.join(adapter_meta.name)
+
+    {:ok, adapter_meta}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    # Ensure leaving the cluster when the cache stops
+    :ok = Cluster.leave(state.name)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@
 _ = Application.start(:telemetry)
 
 # Set nodes
-nodes = [:"node1@127.0.0.1", :"node2@127.0.0.1"]
+nodes = [:"node1@127.0.0.1", :"node2@127.0.0.1", :"iex@127.0.0.1"]
 :ok = Application.put_env(:nebulex, :nodes, nodes)
 
 # Nebulex dependency path


### PR DESCRIPTION
This PR features 2 changes that make node broadcasting slightly better:
1. Skip nodes which names start with `:iex@` to avoid triggering errors on nodes that connect to the cluster to open a remote shell.
2. Call `:erpc.multicast` with a MFA to a named function instead of an anonymous one. `:erpc` can only call a function that exists on remote node and with anonymous function it does indeed exist, but it isn't obvious how it's identified. Calling by MFA will make things more straightforward and also allow for seamless upgrade if the function has to change in the future