### PR TITLE
Postpone joining cluster until Supervisor registers itself

### DIFF
--- a/test/clustered_test.exs
+++ b/test/clustered_test.exs
@@ -17,6 +17,12 @@ defmodule NebulexLocalMultilevelAdapter.ClusteredTest do
          ]}
       ])
 
+    wait_until(fn ->
+      Enum.all?([Cache.Isolated, Cache.Connected], fn cache ->
+        [_, _, _] = Nebulex.Cache.Cluster.get_nodes(cache)
+      end)
+    end)
+
     on_exit(fn ->
       :ok = Process.sleep(100)
       stop_caches(node_pid_list)


### PR DESCRIPTION
In production, we observe this error during deployment:
```elixir
* (ErlangError) Erlang error: {:exception, {%ArgumentError{message: "errors were found at the given arguments:\n\n  * 1st argument: no persistent term stored with this key\n"}, [{:persistent_term, :get, [{Nebulex.Cache.Registry, #PID<71373.5262.0>}], [error_info: %{module: :erl_erts_errors}]}, {Nebulex.Cache.Registry, :lookup, 1, [file: 'lib/nebulex/cache/registry.ex', line: 27]}, {Nebulex.Adapter, :with_meta, 2, [file: 'lib/nebulex/adapter.ex', line: 44]}
```

It turned out, supervisor registers metadata in `:persisten_term` _after_ it starts its children:
https://github.com/cabol/nebulex/blob/c01960235c0da47f701a3bbd70101f48b8837b58/lib/nebulex/cache/supervisor.ex#L86

Which means that if we "join cluster" (by registering in `:pg` group) in child's `init` callback, there's a short period of time during which we will be receiving messages, but won't be able to actually call our cache as it's not present in the registry yet.

As a solution I moved joining cluster into `handle_continue` callback which polls registry every 50ms and only joins cluster after it finds itself there. Alternatively, we could simply rescue `ArgumentError` in `execute_from_remote`:
https://github.com/slab/nebulex_local_multilevel_adapter/blob/53f073da63c605c7658fd8c435dfef86dc712709/lib/nebulex_local_multilevel_adapter.ex#L183-L191
